### PR TITLE
Add drag & drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ Go-notepad will look for the `.notepad.yml` in the following dirs:
 
 ## Current Features
 
-- Simular UI layout of Win XP notepad.
-- Save/open files via terminal or UI.
-- Word Wrap!
+- Simular UI layout of Win XP notepad
+- Save and open files
+- Word Wrap
 - Status Bar
-- Simple config
+- Simple user config
+- Drag & Drop!
 
 ## TODO or Citation Needed
 
@@ -56,7 +57,7 @@ Go-notepad will look for the `.notepad.yml` in the following dirs:
 - Add Find/Replace
 - ~~Add Go To Line.~~
 - Add print functionality.
-- Drag & drop files
+- ~~Drag & drop files.~~
 - Emulate About dialog.
 - Improve makefile for crossplatform support.
 - Add GH workflows for automated deploys.

--- a/textView.go
+++ b/textView.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io/ioutil"
 	"log"
+	"os"
 	"strconv"
 	"time"
 
@@ -39,6 +40,13 @@ func newTextView(app *app) *textView {
 	app.grid.Add(scrolled)
 
 	tv.SetMonospace(true)
+
+	target, err := gtk.TargetEntryNew("text/uri-list", gtk.TargetFlags(0), 0)
+	if err != nil {
+		log.Fatal("failed creating target for textView", err)
+	}
+
+	tv.DragDestSet(gtk.DEST_DEFAULT_ALL, []gtk.TargetEntry{*target}, gdk.ACTION_COPY)
 
 	return &textView{
 		app:         app,
@@ -133,7 +141,7 @@ func (t *textView) Backspace() {
 }
 
 func (t *textView) LoadSource(filename string) (err error) {
-	src, err := ioutil.ReadFile(filename)
+	src, err := os.ReadFile(filename)
 
 	if err != nil {
 		return


### PR DESCRIPTION
Adds drag & drop to go-notepad. Copies the same functionality from notepad on XP to load the first file on the list.